### PR TITLE
Make npm install succeed on Linux.

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -3,13 +3,22 @@
     {
       "target_name": "sspi-client",
       "sources": [
-        "src_native/sspi_client.cpp",
-        "src_native/sspi_impl.cpp",
-        "src_native/utils.cpp"
       ],
       "include_dirs": [
         "<!(node -e \"require('nan')\")"
+      ],
+      "conditions": [
+        [
+          "OS==\"win\"",
+          {
+            "sources": [
+              "src_native/sspi_client.cpp",
+              "src_native/utils.cpp",
+              "src_native/sspi_impl.cpp"
+            ]
+          }
+        ]
       ]
     }
- ]
+  ]
 }

--- a/src_js/fqdn.js
+++ b/src_js/fqdn.js
@@ -45,6 +45,10 @@ function getFqdnForHostname(hostname, cb) {
 
 // Handles IP address, hostname, localhost or FQDN.
 function getFqdn(hostidentifier, cb) {
+  if (os.type() !== 'Windows_NT') {
+    throw new Error('Package currently not-supported on non-Windows platforms.');
+  }
+
   if (net.isIP(hostidentifier)) {
     getFqdnForIpAddress(hostidentifier, cb);
   } else if (hostidentifier.toLowerCase() == localhostIdentifier) {

--- a/src_js/index.js
+++ b/src_js/index.js
@@ -1,4 +1,10 @@
-const sspiClientNative = require('bindings')('sspi-client');
+const os = require('os');
+
+let sspiClientNative;
+
+if (os.type() === 'Windows_NT') {
+  sspiClientNative = require('bindings')('sspi-client');
+}
 
 // SSPI intialization code must only be invoked once. These two variables track
 // whether the intialization code is invoked, completed execution and if
@@ -21,6 +27,10 @@ class SspiClient {
   // Creates an instance of the object in native code, which will invoke
   // Windows SSPI calls.
   constructor(spn, securityPackage) {
+    if (os.type() !== 'Windows_NT') {
+      throw new Error('Package currently not-supported on non-Windows platforms.');
+    }
+
     if (arguments.length !== 1 && arguments.length != 2) {
       throw new Error('Invalid number of arguments.');
     }

--- a/src_js/make_spn.js
+++ b/src_js/make_spn.js
@@ -1,4 +1,10 @@
+const os = require('os');
+
 function makeSpn(serviceClassname, fqdn, instanceNameOrPort, cb) {
+  if (os.type() !== 'Windows_NT') {
+    throw new Error('Package currently not-supported on non-Windows platforms.');
+  }
+
   return serviceClassname + '/' + fqdn + ':' + instanceNameOrPort;
 }
 


### PR DESCRIPTION
- Move source files in binding.gyp into "conditions" sections so they
  build only for Windows.
- Throw platform not supported exception in all public API for on
  non-windows platforms.

https://github.com/tvrprasad/sspi-client/issues/31
