### PR TITLE
Supporting Node 14

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sspi-client",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "SSPI Client Library.",
   "author": "Prasad Tammana <prasadgithub@gmail.com>",
   "license": "MIT",

--- a/src_native/sspi_client.cpp
+++ b/src_native/sspi_client.cpp
@@ -208,7 +208,7 @@ NAN_METHOD(InitializeAsync)
 NAN_METHOD(EnableDebugLogging)
 {
     DebugLog("%ul: Main event loop: EnableDebugLogging NAN_METHOD.\n", GetCurrentThreadId());
-    SetDebugLogging(info[0]->BooleanValue());
+    SetDebugLogging(Nan::To<bool>(info[0]).FromJust());
 }
 
 // Native implementation of SspiClient surfaced to JavaScript.
@@ -286,13 +286,13 @@ private:
     {
         DebugLog("%ul: Main event loop: SspiClientObject::GetNextBlob.\n", GetCurrentThreadId());
 
-        int inBlobBeginOffset = static_cast<int>(info[1]->IntegerValue());
-        int inBlobLength = static_cast<int>(info[2]->IntegerValue());
+        int inBlobBeginOffset = static_cast<int>(Nan::To<int>(info[1]).FromJust());
+        int inBlobLength = static_cast<int>(Nan::To<int>(info[2]).FromJust());
 
         char* inBlob = nullptr;
         if (inBlobLength > 0)
         {
-            inBlob = node::Buffer::Data(info[0]->ToObject());
+            inBlob = node::Buffer::Data(info[0]->ToObject(Nan::GetCurrentContext()).ToLocalChecked());
         }
 
         Nan::Callback* callback = new Nan::Callback(info[3].As<v8::Function>());
@@ -309,14 +309,14 @@ private:
     {
         DebugLog("%ul: Main event loop: SspiClientObject::UtEnableCannedResponse.\n", GetCurrentThreadId());
         SspiClientObject* sspiClientObject = Nan::ObjectWrap::Unwrap<SspiClientObject>(info.Holder());
-        sspiClientObject->m_sspiImpl->UtEnableCannedResponse(info[0]->BooleanValue());
+        sspiClientObject->m_sspiImpl->UtEnableCannedResponse(Nan::To<bool>(info[0]).FromJust());
     }
 
     static NAN_METHOD(UtForceCompleteAuth)
     {
         DebugLog("%ul: Main event loop: SspiClientObject::UtForceCompleteAuth.\n", GetCurrentThreadId());
         SspiClientObject* sspiClientObject = Nan::ObjectWrap::Unwrap<SspiClientObject>(info.Holder());
-        sspiClientObject->m_sspiImpl->UtForceCompleteAuth(info[0]->BooleanValue());
+        sspiClientObject->m_sspiImpl->UtForceCompleteAuth(Nan::To<bool>(info[0]).FromJust());
     }
 
     // This is a shared pointer because we pass this to


### PR DESCRIPTION
**Re-creating a PR for a request originally opened [here](https://github.com/tvrprasad/sspi-client/pull/43) on the 24th of May 2020 to point at the pull-request branch rather than master**

Noticed the sspi-client module does not support the newer versions of NodeJS due to errors such as 

> error C2660: 'v8::Value::BooleanValue': function does not take 0 arguments

These APIs were previously marked as depreciated and were removed in **Node 12**. The change I'm making here will allow this module to support the newer (and older) versions of Node. I verified the module could be built against

* 14.2.0
* 12.16.3
* 10.19.0 

I have not been able to successfully run all the tests with `npm test`. But the results I get for the original source code and the code with my changes, across the different node versions, match. I've been able to integrate a local version of the sspi-client, with my changes, into an app and it worked.

The test results I could achieved are 

    PS C:\Development\sspi-client-original> npm test

    > sspi-client@0.1.0 test C:\Development\sspi-client-original
    > nodeunit test/unit/


    fqdn_tests
    Test: hostidentifier 127.0.0.1, expectedFqdnPattern /^localhost.cisco.com$/, fqdn localhost.cisco.com, error: null
    ✔ loopbackIpAddress
    Test: hostidentifier 31.13.77.36, expectedFqdnPattern /^.*\.facebook.com$/, fqdn edge-snaptu-http-mini-shv-01-hkt1.facebook.com, error: null
    ✔ ipv4Address
    Test: hostidentifier 2a03:2880:f127:83:face:b00c:0:25de, expectedFqdnPattern /^.*\.facebook.com$/, fqdn edge-star-mini6-shv-01-ort2.facebook.com, error: null
    ✔ ipv6Address
    Test: hostidentifier localhost.cisco.com, expectedFqdnPattern /^localhost.cisco.com$/, fqdn localhost.cisco.com, error: null
    ✔ simpleHostname
    Test: hostidentifier localhost.cisco.com, expectedFqdnPattern /^localhost.cisco.com$/, fqdn localhost.cisco.com, error: null
    ✔ localhostLowerCase
    Test: hostidentifier LOCALHOST.cisco.com, expectedFqdnPattern LOCALHOST.cisco.com, fqdn LOCALHOST.cisco.com, error: null
    ✔ localhostUpperCase
    Test: hostidentifier LoCaLhOsT.cisco.com, expectedFqdnPattern LoCaLhOsT.cisco.com, fqdn LoCaLhOsT.cisco.com, error: null
    ✔ localhostMixedCase
    Test: hostidentifier abc.example.com, expectedFqdnPattern /^abc.example.com$/, fqdn abc.example.com, error: null
    ✔ hostFqdn
    ✖ invalidIpaddress

    Assertion Message: fqdn: one.one.one.one err: null
    AssertionError: null !== null
        at Object.notStrictEqual (C:\Development\sspi-client-original\node_modules\nodeunit\lib\types.js:83:39)
        at Fqdn.getFqdn (C:\Development\sspi-client-original\test\unit\fqdn_tests.js:56:10)
        at QueryReqWrap.callback (C:\Development\sspi-client-original\src_js\fqdn.js:17:7)
        at QueryReqWrap.onresolve [as oncomplete] (dns.js:198:10)

    ✔ invalidHostname

    make_spn_tests
    ✔ makeSpnPort
    ✔ makeSpnInstanceName

    sspi_client_tests
    ✔ ensureInitializationNoCallback
    ✔ ensureInitializationWithCallback
    ✔ ensureInitializationTooManyArgs
    ✔ ensureInitializationInvalidArgTypeCb
    ✔ constructorSuccess
    ✔ constructorEmptyArgs
    ✔ constructorTooManyArgs
    ✔ constructorInvalidArgTypeSpn
    ✔ constructorInvalidArgTypeSecurityPackage
    ✔ constructorEmptyStringSpn
    ✔ constructorInvalidSecurityPackage
    ✔ getNextBlobBasic
    ✖ getNextBlobBasicNegotiate

    AssertionError: false == true
        at Object.ok (C:\Development\sspi-client-original\node_modules\nodeunit\lib\types.js:83:39)
        at sspiClient.getNextBlob (C:\Development\sspi-client-original\test\unit\sspi_client_tests.js:181:12)
        at C:\Development\sspi-client-original\src_js\sspi_client.js:158:16

    AssertionError: 2148074242 === 0
        at Object.strictEqual (C:\Development\sspi-client-original\node_modules\nodeunit\lib\types.js:83:39)
        at sspiClient.getNextBlob (C:\Development\sspi-client-original\test\unit\sspi_client_tests.js:183:12)
        at C:\Development\sspi-client-original\src_js\sspi_client.js:158:16

    AssertionError: 'CompleteAuthToken failed with error code: 0x80090302.' === ''
        at Object.strictEqual (C:\Development\sspi-client-original\node_modules\nodeunit\lib\types.js:83:39)
        at sspiClient.getNextBlob (C:\Development\sspi-client-original\test\unit\sspi_client_tests.js:184:12)
        at C:\Development\sspi-client-original\src_js\sspi_client.js:158:16

    AssertionError: false == true
        at Object.ok (C:\Development\sspi-client-original\node_modules\nodeunit\lib\types.js:83:39)
        at sspiClient.getNextBlob (C:\Development\sspi-client-original\test\unit\sspi_client_tests.js:203:12)
        at C:\Development\sspi-client-original\src_js\sspi_client.js:158:16

    AssertionError: false == true
        at Object.ok (C:\Development\sspi-client-original\node_modules\nodeunit\lib\types.js:83:39)
        at sspiClient.getNextBlob (C:\Development\sspi-client-original\test\unit\sspi_client_tests.js:204:12)
        at C:\Development\sspi-client-original\src_js\sspi_client.js:158:16

    ✖ getNextBlobBasicKerberos

    AssertionError: false == true
        at Object.ok (C:\Development\sspi-client-original\node_modules\nodeunit\lib\types.js:83:39)
        at sspiClient.getNextBlob (C:\Development\sspi-client-original\test\unit\sspi_client_tests.js:181:12)
        at C:\Development\sspi-client-original\src_js\sspi_client.js:158:16

    AssertionError: 2148074242 === 0
        at Object.strictEqual (C:\Development\sspi-client-original\node_modules\nodeunit\lib\types.js:83:39)
        at sspiClient.getNextBlob (C:\Development\sspi-client-original\test\unit\sspi_client_tests.js:183:12)
        at C:\Development\sspi-client-original\src_js\sspi_client.js:158:16

    AssertionError: 'CompleteAuthToken failed with error code: 0x80090302.' === ''
        at Object.strictEqual (C:\Development\sspi-client-original\node_modules\nodeunit\lib\types.js:83:39)
        at sspiClient.getNextBlob (C:\Development\sspi-client-original\test\unit\sspi_client_tests.js:184:12)
        at C:\Development\sspi-client-original\src_js\sspi_client.js:158:16

    AssertionError: false == true
        at Object.ok (C:\Development\sspi-client-original\node_modules\nodeunit\lib\types.js:83:39)
        at sspiClient.getNextBlob (C:\Development\sspi-client-original\test\unit\sspi_client_tests.js:203:12)
        at C:\Development\sspi-client-original\src_js\sspi_client.js:158:16

    AssertionError: false == true
        at Object.ok (C:\Development\sspi-client-original\node_modules\nodeunit\lib\types.js:83:39)
        at sspiClient.getNextBlob (C:\Development\sspi-client-original\test\unit\sspi_client_tests.js:204:12)
        at C:\Development\sspi-client-original\src_js\sspi_client.js:158:16

    ✖ getNextBlobBasicNtlm

    AssertionError: false == true
        at Object.ok (C:\Development\sspi-client-original\node_modules\nodeunit\lib\types.js:83:39)
        at sspiClient.getNextBlob (C:\Development\sspi-client-original\test\unit\sspi_client_tests.js:181:12)
        at C:\Development\sspi-client-original\src_js\sspi_client.js:158:16

    AssertionError: 2148074242 === 0
        at Object.strictEqual (C:\Development\sspi-client-original\node_modules\nodeunit\lib\types.js:83:39)
        at sspiClient.getNextBlob (C:\Development\sspi-client-original\test\unit\sspi_client_tests.js:183:12)
        at C:\Development\sspi-client-original\src_js\sspi_client.js:158:16

    AssertionError: 'CompleteAuthToken failed with error code: 0x80090302.' === ''
        at Object.strictEqual (C:\Development\sspi-client-original\node_modules\nodeunit\lib\types.js:83:39)
        at sspiClient.getNextBlob (C:\Development\sspi-client-original\test\unit\sspi_client_tests.js:184:12)
        at C:\Development\sspi-client-original\src_js\sspi_client.js:158:16

    AssertionError: false == true
        at Object.ok (C:\Development\sspi-client-original\node_modules\nodeunit\lib\types.js:83:39)
        at sspiClient.getNextBlob (C:\Development\sspi-client-original\test\unit\sspi_client_tests.js:203:12)
        at C:\Development\sspi-client-original\src_js\sspi_client.js:158:16

    AssertionError: false == true
        at Object.ok (C:\Development\sspi-client-original\node_modules\nodeunit\lib\types.js:83:39)
        at sspiClient.getNextBlob (C:\Development\sspi-client-original\test\unit\sspi_client_tests.js:204:12)
        at C:\Development\sspi-client-original\src_js\sspi_client.js:158:16

    ✖ getNextBlobBasicForceCompleteAuth

    AssertionError: false == true
        at Object.ok (C:\Development\sspi-client-original\node_modules\nodeunit\lib\types.js:83:39)
        at sspiClient.getNextBlob (C:\Development\sspi-client-original\test\unit\sspi_client_tests.js:181:12)
        at C:\Development\sspi-client-original\src_js\sspi_client.js:158:16

    AssertionError: 2148074242 === 0
        at Object.strictEqual (C:\Development\sspi-client-original\node_modules\nodeunit\lib\types.js:83:39)
        at sspiClient.getNextBlob (C:\Development\sspi-client-original\test\unit\sspi_client_tests.js:183:12)
        at C:\Development\sspi-client-original\src_js\sspi_client.js:158:16

    AssertionError: 'CompleteAuthToken failed with error code: 0x80090302.' === ''
        at Object.strictEqual (C:\Development\sspi-client-original\node_modules\nodeunit\lib\types.js:83:39)
        at sspiClient.getNextBlob (C:\Development\sspi-client-original\test\unit\sspi_client_tests.js:184:12)
        at C:\Development\sspi-client-original\src_js\sspi_client.js:158:16

    AssertionError: false == true
        at Object.ok (C:\Development\sspi-client-original\node_modules\nodeunit\lib\types.js:83:39)
        at sspiClient.getNextBlob (C:\Development\sspi-client-original\test\unit\sspi_client_tests.js:203:12)
        at C:\Development\sspi-client-original\src_js\sspi_client.js:158:16

    AssertionError: false == true
        at Object.ok (C:\Development\sspi-client-original\node_modules\nodeunit\lib\types.js:83:39)
        at sspiClient.getNextBlob (C:\Development\sspi-client-original\test\unit\sspi_client_tests.js:204:12)
        at C:\Development\sspi-client-original\src_js\sspi_client.js:158:16

    ✔ getNextBlobCannedResponseEmptyInBuf
    ✔ getNextBlobCannedResponseNonEmptyInBuf
    ✔ getNextBlobMultipleInCallbacksSameInstance
    ✔ getNextBlobMultipleInProgressSameInstanceFails
    ✔ getNextBlobInvalidNumberOfArgs
    ✔ getNextBlobInvalidServerResponseArg
    ✔ getNextBlobInvalidServerResponseLengthArg
    ✔ getNextBlobInvalidServerResponseBeginOffsetArg
    ✔ getNextBlobBufferTooSmall
    ✔ getNextBlobInvalidCallbackArg

    FAILURES: 21/715 assertions failed (11832ms)
    npm ERR! Test failed.  See above for more details.

@tvrprasad if you're satisfied with these changes would it be possible to publish a new release?